### PR TITLE
Update representation color

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@ npm run watch
   - [Ligand with surrounding](https://codesandbox.io/p/sandbox/github/molstar/example-gallery/master/selection/select_ligand_and_surroundings)
 - Representation
   - [Create representations](https://codesandbox.io/p/sandbox/github/molstar/example-gallery/master/representation/create_representations)
+  - [Update representations](https://codesandbox.io/p/sandbox/github/molstar/example-gallery/master/representation/update_representations)
   - [Set transparency on selection](https://codesandbox.io/p/sandbox/github/molstar/example-gallery/master/representation/transparency_using_selection)
 - [Default](https://codesandbox.io/p/sandbox/github/molstar/example-gallery/master/default)
 

--- a/representation/create_representations/src/index.ts
+++ b/representation/create_representations/src/index.ts
@@ -2,7 +2,7 @@ import { StructureSelectionQueries } from "molstar/lib/mol-plugin-state/helpers/
 import { createRootViewer } from "./common/init";
 
 async function init() {
-    // plugin initialization logic bundled for usage in CodePen. Returns a PluginContext
+  // Create Viewer. Returns a PluginContext
   const plugin = await createRootViewer();
 
   // The `builders` namespace contains a set of helper functions to create and manipulate structures, representations, etc.

--- a/representation/transparency_using_selection/src/index.ts
+++ b/representation/transparency_using_selection/src/index.ts
@@ -6,12 +6,12 @@ async function init() {
     // Create viewer
     const plugin = await createRootViewer();
     
-    // Download PDB
+    // Download mmCIF
     const fileData = await plugin.builders.data.download(
         { url: "https://models.rcsb.org/4hhb.bcif", isBinary: true }
     );
 
-    // Load PDB and create representation
+    // Load mmCIF and create representation
     const trajectory = await plugin.builders.structure.parseTrajectory(fileData, "mmcif");
     const presetStateObjects = await plugin.builders.structure.hierarchy.applyPreset(trajectory, "default");
 

--- a/representation/update_representations/index.html
+++ b/representation/update_representations/index.html
@@ -1,0 +1,20 @@
+<html>
+  <head>
+    <title>Mol* Gallery</title>
+    <meta charset="UTF-8" />
+  </head>
+
+  <body style="font-family: sans-serif; height: 100%; width: 100%; margin: 0; display: flex; flex-direction: column;">
+    <div style="margin: 20px auto">
+      <button id="byres">Color by residue</button>
+      <button id="bypos">Color by position</button>
+      <button id="bychain">Color by chain</button>
+    </div>
+    <div style="flex: 1 1 auto; padding: 0 40px 40px">
+      <div id="app" style="outline: 1px dotted #ccc">
+        <canvas id="canvas" style="height: 100%;width: 100%;"></canvas>
+      </div>
+    </div>
+    <script src="src/index.ts"></script>
+  </body>
+</html>

--- a/representation/update_representations/package.json
+++ b/representation/update_representations/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "molstar-typescript-example",
+    "version": "1.0.0",
+    "description": "Molstar and TypeScript example starter project",
+    "main": "index.html",
+    "scripts": {
+      "start": "parcel index.html",
+      "build": "parcel build index.html"
+    },
+    "dependencies": {
+      "parcel-bundler": "1.12.5",
+      "molstar": "4.3.0"
+    },
+    "devDependencies": {
+      "typescript": "4.4.4"
+    },
+    "resolutions": {
+      "@babel/preset-env": "7.13.8"
+    },
+    "keywords": [
+      "typescript",
+      "molstar"
+    ]
+  }

--- a/representation/update_representations/src/common/init.ts
+++ b/representation/update_representations/src/common/init.ts
@@ -1,0 +1,19 @@
+import { PluginContext } from "molstar/lib/mol-plugin/context";
+import { DefaultPluginSpec } from "molstar/lib/mol-plugin/spec";
+
+export async function createRootViewer() {
+  const viewport = document.getElementById("app") as HTMLDivElement;
+  const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+
+  const plugin = new PluginContext(DefaultPluginSpec());
+  await plugin.init();
+
+  if (!plugin.initViewer(canvas, viewport)) {
+    viewport.innerHTML = "Failed to init Mol*";
+    throw new Error("init failed");
+  }
+  //@ts-ignore
+  window["molstar"] = plugin;
+
+  return plugin;
+}

--- a/representation/update_representations/src/index.ts
+++ b/representation/update_representations/src/index.ts
@@ -1,0 +1,81 @@
+import { createRootViewer } from "./common/init";
+import { StateBuilder, StateSelection, StateTransform } from "molstar/lib/mol-state";
+import { createStructureRepresentationParams } from "molstar/lib/mol-plugin-state/helpers/structure-representation-params";
+
+const byres = document.getElementById("byres")!;
+const bychain = document.getElementById("bychain")!;
+const bypos = document.getElementById("bypos")!;
+
+async function init() {
+  // Create Viewer. Returns a PluginContext
+  const plugin = await createRootViewer();
+
+  // Download data as mmCIF
+  const fileData = await plugin.builders.data.download({
+    url: "https://models.rcsb.org/5ee7.bcif",
+    isBinary: true,
+  });
+
+  // Load mmCIF and create trajectory -> model -> structure -> representation
+  const trajectorySO = await plugin.builders.structure.parseTrajectory(
+    fileData,
+    "mmcif"
+  );
+
+  const modelSO = await plugin.builders.structure.createModel(trajectorySO);
+  
+  // Structure StateObject Selector (object from the state tree that represents the structure)
+  const structureSO = await plugin.builders.structure.createStructure(modelSO); 
+  // Structure object contains properties and accessors to the underlying molecular data such as chains, residues, atoms, etc.
+  const structure = structureSO.data!;
+  
+  const representationSO = await plugin.builders.structure.representation.addRepresentation(
+    structureSO,    // we pass a structure StateObject Selector to apply the representation on the whole structure
+    {
+      type: "cartoon",
+      color: "chain-id",
+    },
+    { tag: "my-cartoon" } // tag is optional. It is used in some examples to retrieve the representation from the state tree.
+  );
+
+
+  // Color by residue name
+  // In this example, the Representation StateObject is used directly. 
+  // Internally, the `update` function acts on a new State tree and returns a helper StateBuilder object
+  // which may receive additional changes.
+  // The `commit` function is used to apply the changes to the current plugin state.
+  byres.addEventListener("click", () => {
+    const newParams = createStructureRepresentationParams(plugin, structure, { color: "residue-name" });
+    const update = representationSO.update(newParams) as StateBuilder.Root
+    update.commit()
+  });
+
+  // Color by chain
+  // In this example the `ref` string for the representation is found back from the state tree using
+  // the tag that was set at creation time.
+  bychain.addEventListener("click", async () => {
+    const newParams = createStructureRepresentationParams(plugin, structure, { color: "chain-id" });
+    const reprRef = StateSelection.findTagInSubtree(plugin.state.data.tree, StateTransform.RootRef, "my-cartoon");
+    
+    if (!reprRef) throw new Error("Representation not found");
+    
+    plugin.build().to(reprRef).update(newParams).commit()
+  });
+
+  // Color by position
+  // In this example the representation object to update is found back from the state tree using a state
+  // selector function which takes a tag as argument. This returns a sequence of state cells because there
+  // can be multiple matches when using the `select` method.
+  bypos.addEventListener("click", () => {
+    const newParams = createStructureRepresentationParams(plugin, structureSO.data, { color: "sequence-id" });
+    const repr = plugin.state.data.select(StateSelection.Generators.root.subtree().withTag("my-cartoon"));
+    
+    const update = plugin.build();  // Start a new state tree
+    for (const r of repr) {
+      update.to(r).update(newParams); // update the new state tree
+    }
+    update.commit();  // apply all the changes to the current plugin state.
+  });
+
+}
+init();

--- a/representation/update_representations/tsconfig.json
+++ b/representation/update_representations/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+      "strict": true,
+      "module": "commonjs",
+      "jsx": "preserve",
+      "esModuleInterop": true,
+      "sourceMap": true,
+      "allowJs": true,
+      "lib": [
+        "es6",
+        "dom"
+      ],
+      "rootDir": "src",
+      "moduleResolution": "node"
+    }
+  }


### PR DESCRIPTION
This PR demos how to update a pre-existing representation.

It showcases how to use the representation state object selector that's returned when the representation is created and how to find back a representation using its tag.
The other main aspect of the example is to show that the updates are always managed through the state.

### Specific review requests
- Are the explanations about the state sufficient?
- We had a discussion about how to retrieve a representation from the plugin structure hierarchy. I haven't found a convenient way of doing this. Maybe this could be added.
- Are there anti-patterns in the examples?
- Are there more efficient ways of doing this?