### PR TITLE
Save/Load session, Load from file examples

### DIFF
--- a/IO/load_file/index.html
+++ b/IO/load_file/index.html
@@ -1,0 +1,15 @@
+<html>
+  <head>
+    <title>Mol* Gallery</title>
+    <meta charset="UTF-8" />
+  </head>
+
+  <body style="font-family: sans-serif; height: 100%; width: 100%; margin: 0;">
+    <label>Load: </label><input type='file' id='load'/>
+    <div id="app" style="height: 100%;width: 100%;">
+      <canvas id="canvas" style="height: 100%;width: 100%;"></canvas>
+    </div>
+
+    <script src="src/index.ts"></script>
+  </body>
+</html>

--- a/IO/load_file/package.json
+++ b/IO/load_file/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "molstar-typescript-example",
+    "version": "1.0.0",
+    "description": "Molstar and TypeScript example starter project",
+    "main": "index.html",
+    "scripts": {
+      "start": "parcel index.html",
+      "build": "parcel build index.html"
+    },
+    "dependencies": {
+      "parcel-bundler": "1.12.5",
+      "molstar": "4.3.0"
+    },
+    "devDependencies": {
+      "typescript": "4.4.4"
+    },
+    "resolutions": {
+      "@babel/preset-env": "7.13.8"
+    },
+    "keywords": [
+      "typescript",
+      "molstar"
+    ]
+  }

--- a/IO/load_file/src/common/init.ts
+++ b/IO/load_file/src/common/init.ts
@@ -1,0 +1,19 @@
+import { PluginContext } from "molstar/lib/mol-plugin/context";
+import { DefaultPluginSpec } from "molstar/lib/mol-plugin/spec";
+
+export async function createRootViewer() {
+  const viewport = document.getElementById("app") as HTMLDivElement;
+  const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+
+  const plugin = new PluginContext(DefaultPluginSpec());
+  await plugin.init();
+
+  if (!plugin.initViewer(canvas, viewport)) {
+    viewport.innerHTML = "Failed to init Mol*";
+    throw new Error("init failed");
+  }
+  //@ts-ignore
+  window["molstar"] = plugin;
+
+  return plugin;
+}

--- a/IO/load_file/src/index.ts
+++ b/IO/load_file/src/index.ts
@@ -1,0 +1,37 @@
+import { PluginContext } from "molstar/lib/mol-plugin/context";
+import { OpenFiles } from "molstar/lib/mol-plugin-state/actions/file";
+import { createRootViewer } from "./common/init";
+import { Asset } from "molstar/lib/mol-util/assets";
+
+async function init() {
+    // Create viewer
+    const plugin = await createRootViewer();
+
+    // Set up save/load buttons and events for with and without assets
+    document.getElementById('load')!.oninput = (e) => loadFile(plugin, e);
+}
+init();
+
+async function loadFile(plugin: PluginContext, event: Event) {
+    // Get the input element
+    const input = event.target as HTMLInputElement;
+    // If there are no files, return
+    if (!input.files || input.files.length === 0) return;
+
+    // Convert the FileList into Asset.File[] for the plugin
+    const files = Array.from(input.files);
+    const assetFiles = files.map(f => Asset.File(f));
+
+    // Create a task to OpenFiles
+    const task = plugin.state.data.applyAction(OpenFiles, {
+        files: assetFiles,  // AssetFiles from input
+        format: {
+            name: 'auto',   // Format of the file can be autodetermined (.pdb, .cif, etc.)
+            params: {}      // No special parameters
+        },
+        visuals: true       // Create the visual representations
+    })
+    
+    // Run the task to OpenFiles
+    plugin.runTask(task)
+}

--- a/IO/load_file/tsconfig.json
+++ b/IO/load_file/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+      "strict": true,
+      "module": "commonjs",
+      "jsx": "preserve",
+      "esModuleInterop": true,
+      "sourceMap": true,
+      "allowJs": true,
+      "lib": [
+        "es6",
+        "dom"
+      ],
+      "rootDir": "src",
+      "moduleResolution": "node"
+    }
+  }

--- a/IO/save_session/index.html
+++ b/IO/save_session/index.html
@@ -1,0 +1,22 @@
+<html>
+  <head>
+    <title>Mol* Gallery</title>
+    <meta charset="UTF-8" />
+  </head>
+
+  <body style="font-family: sans-serif; height: 100%; width: 100%; margin: 0;">
+    <label>Save Snapshot (with Assets): </label><button id="saveAssets">Download</button>
+    <br>
+    <label>Load Snapshot (with Assets): </label><input type='file' id='loadAssets' accept=".molx"/>
+    <br>
+    <label>Save Snapshot (without Assets): </label><button id="saveNoAssets">Download</button>
+    <br>
+    <label>Load Snapshot (without Assets): </label><input type='file' id='loadNoAssets' accept=".molj"/>
+    <!-- <button onClick={handleStateButtonClick}>Load State</button> -->
+    <div id="app" style="height: 100%;width: 100%;">
+      <canvas id="canvas" style="height: 100%;width: 100%;"></canvas>
+    </div>
+
+    <script src="src/index.ts"></script>
+  </body>
+</html>

--- a/IO/save_session/index.html
+++ b/IO/save_session/index.html
@@ -12,7 +12,6 @@
     <label>Save Snapshot (without Assets): </label><button id="saveNoAssets">Download</button>
     <br>
     <label>Load Snapshot (without Assets): </label><input type='file' id='loadNoAssets' accept=".molj"/>
-    <!-- <button onClick={handleStateButtonClick}>Load State</button> -->
     <div id="app" style="height: 100%;width: 100%;">
       <canvas id="canvas" style="height: 100%;width: 100%;"></canvas>
     </div>

--- a/IO/save_session/package.json
+++ b/IO/save_session/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "molstar-typescript-example",
+    "version": "1.0.0",
+    "description": "Molstar and TypeScript example starter project",
+    "main": "index.html",
+    "scripts": {
+      "start": "parcel index.html",
+      "build": "parcel build index.html"
+    },
+    "dependencies": {
+      "parcel-bundler": "1.12.5",
+      "molstar": "4.3.0"
+    },
+    "devDependencies": {
+      "typescript": "4.4.4"
+    },
+    "resolutions": {
+      "@babel/preset-env": "7.13.8"
+    },
+    "keywords": [
+      "typescript",
+      "molstar"
+    ]
+  }

--- a/IO/save_session/src/common/init.ts
+++ b/IO/save_session/src/common/init.ts
@@ -1,0 +1,19 @@
+import { PluginContext } from "molstar/lib/mol-plugin/context";
+import { DefaultPluginSpec } from "molstar/lib/mol-plugin/spec";
+
+export async function createRootViewer() {
+  const viewport = document.getElementById("app") as HTMLDivElement;
+  const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+
+  const plugin = new PluginContext(DefaultPluginSpec());
+  await plugin.init();
+
+  if (!plugin.initViewer(canvas, viewport)) {
+    viewport.innerHTML = "Failed to init Mol*";
+    throw new Error("init failed");
+  }
+  //@ts-ignore
+  window["molstar"] = plugin;
+
+  return plugin;
+}

--- a/IO/save_session/src/index.ts
+++ b/IO/save_session/src/index.ts
@@ -1,0 +1,51 @@
+import { PluginContext } from "molstar/lib/mol-plugin/context";
+import { createRootViewer } from "./common/init";
+import { download } from "molstar/lib/mol-util/download";
+
+async function init() {
+    // Create viewer
+    const plugin = await createRootViewer();
+    
+    // Download PDB
+    const fileData = await plugin.builders.data.download(
+        { url: "https://models.rcsb.org/4hhb.bcif", isBinary: true }
+    );
+
+    // Load PDB and create representation
+    const trajectory = await plugin.builders.structure.parseTrajectory(fileData, "mmcif");
+    await plugin.builders.structure.hierarchy.applyPreset(trajectory, "default");
+
+    // Set up save/load buttons and events for with and without assets
+    // Assets refer to the files used to initially load the data (in this case a .bcif from the RCSB)
+    
+    // If you save with assets (.molx), you can load the session without having to re-download the data
+    document.getElementById('saveAssets')!.onclick = (e) => saveState(plugin, 'molx');
+    document.getElementById('loadAssets')!.oninput = (e) => loadState(plugin, e);
+    // If you save without assets (.molj), you will need to either keep the existing assets
+    // in the viewer or load them prior to loading the session
+    document.getElementById('saveNoAssets')!.onclick = (e) => saveState(plugin, 'molj');
+    document.getElementById('loadNoAssets')!.onchange = (e) => loadState(plugin, e);
+}
+init();
+
+async function saveState(plugin: PluginContext, type: 'molx' | 'molj') {
+    // Here we serialize the snapshot into a Blob
+    // There is also the helper command `PluginCommands.State.Snapshots.DownloadToFile`
+    // which is more high-level but does not let you set the file name
+    const data = await plugin.managers.snapshot.serialize({type})
+
+    // Next, we download the Blob and give it a filename
+    download(data, `state.${type}`);
+}
+
+async function loadState(plugin: PluginContext, event: Event) {
+    // Get the input element
+    const input = event.target as HTMLInputElement;
+    // If there are no files, return
+    if (!input.files || input.files.length === 0) return;
+
+    // Here we open the snapshot from the file
+    // There is also the helper command `PluginCommands.State.Snapshots.OpenFile`
+    // which does the same thing.
+    await plugin.managers.snapshot.open(input.files[0]);
+}

--- a/IO/save_session/tsconfig.json
+++ b/IO/save_session/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+      "strict": true,
+      "module": "commonjs",
+      "jsx": "preserve",
+      "esModuleInterop": true,
+      "sourceMap": true,
+      "allowJs": true,
+      "lib": [
+        "es6",
+        "dom"
+      ],
+      "rootDir": "src",
+      "moduleResolution": "node"
+    }
+  }

--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,9 @@ npm run watch
   - [Set transparency on selection](https://codesandbox.io/p/sandbox/github/molstar/example-gallery/master/representation/transparency_using_selection)
 - Coloring
   - [Color a selection](https://codesandbox.io/p/sandbox/github/molstar/example-gallery/master/coloring/color_a_selection)
+- IO
+  - [Load file](https://codesandbox.io/p/sandbox/github/molstar/example-gallery/master/io/load_file)
+  - [Save session](https://codesandbox.io/p/sandbox/github/molstar/example-gallery/master/io/save_session)
 - [Default](https://codesandbox.io/p/sandbox/github/molstar/example-gallery/master/default)
 
 ## Prebuilt Examples and CodePens


### PR DESCRIPTION
## Overview
This PR creates 2 new examples for saving/loading a session (with and without Assets) as well as loading a structure from file (.pdb, .cif, etc.).

## Changes made
- Created io example "save_session"
  - This example shows you how to save and load sessions you created
  - You can save a session with and without assets in the file object.
- Created io example "load_file"
  - This example shows you how to load a structure into the viewer from a file

## How to test
Ensure you can save and load a session
- With assets: move the camera around, save, reload the page, load from file (`.molx`)
- Without assets: move the camera around, save, move the camera more, load from file (`.molj`)
- [save_session](https://codesandbox.io/p/sandbox/github/molstar/example-gallery/tree/save-session/io/save_session)

Ensure different structures can be loaded into the viewer (`.pdb, .cif, etc.`)
- [load_file](https://codesandbox.io/p/sandbox/github/molstar/example-gallery/tree/save-session/io/load_file)

## Specific review requests
For each of the examples:
- Are there enough comments to sufficiently describe the process?
- Are the comments accurately describing the process?
- Are there any anti-patterns in the examples?
- Can the examples be more efficient?